### PR TITLE
feat(ingestion/ldap): flag to ingest ldap users with email instead of username

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -392,10 +392,10 @@ class LDAPSource(StatefulIngestionSourceBase):
 
         manager_urn = f"urn:li:corpuser:{manager_ldap}" if manager_ldap else None
 
-        user_urn = email if self.config.use_email_as_username else ldap_user
+        make_user_urn = email if self.config.use_email_as_username else ldap_user
 
         user_snapshot = CorpUserSnapshotClass(
-            urn=f"urn:li:corpuser:{user_urn}",
+            urn=f"urn:li:corpuser:{make_user_urn}",
             aspects=[
                 CorpUserInfoClass(
                     active=True,
@@ -436,10 +436,10 @@ class LDAPSource(StatefulIngestionSourceBase):
                 attrs, self.config.group_attrs_map["displayName"]
             )
 
-            group_urn = email if self.config.use_email_as_username else full_name
+            make_group_urn = email if self.config.use_email_as_username else full_name
 
             group_snapshot = CorpGroupSnapshotClass(
-                urn=f"urn:li:corpGroup:{group_urn}",
+                urn=f"urn:li:corpGroup:{make_group_urn}",
                 aspects=[
                     CorpGroupInfoClass(
                         email=email,

--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -310,6 +310,7 @@ class LDAPSource(StatefulIngestionSourceBase):
         Handle a DN and attributes by adding manager info and constructing a
         work unit based on the information.
         """
+        manager_ldap = None
         make_manager_urn = None
         if self.config.user_attrs_map["managerUrn"] in attrs:
             try:

--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -310,7 +310,7 @@ class LDAPSource(StatefulIngestionSourceBase):
         Handle a DN and attributes by adding manager info and constructing a
         work unit based on the information.
         """
-        manager_ldap = None
+        make_manager_urn = None
         if self.config.user_attrs_map["managerUrn"] in attrs:
             try:
                 m_cn = attrs[self.config.user_attrs_map["managerUrn"]][0].decode()
@@ -327,10 +327,19 @@ class LDAPSource(StatefulIngestionSourceBase):
                 result = self.ldap_client.result3(manager_msgid)
                 if result[1]:
                     _m_dn, m_attrs = result[1][0]
+
                     manager_ldap = guess_person_ldap(m_attrs, self.config, self.report)
+
+                    m_email = get_attr_or_none(
+                        m_attrs, self.config.user_attrs_map["email"], manager_ldap
+                    )
+                    make_manager_urn = (
+                        m_email if self.config.use_email_as_username else manager_ldap
+                    )
+
             except ldap.LDAPError as e:
                 self.report.report_warning(dn, f"manager LDAP search failed: {e}")
-        mce = self.build_corp_user_mce(dn, attrs, manager_ldap)
+        mce = self.build_corp_user_mce(dn, attrs, make_manager_urn)
         if mce:
             yield MetadataWorkUnit(dn, mce)
         else:


### PR DESCRIPTION
Added a flag (use_email_as_username) to the LDAP source
that makes it produce urns with full emails instead of urns with usernames.
This applies while creating urn for `users`,`managers` & `groups`.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
