### PR TITLE
feat(ingest): allow weekly stripping based on md5 hash of table/data-set name

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -41,6 +41,9 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionSourceBase,
 )
+from datahub.ingestion.source_config.operation_config import (
+    is_hash_mod_matching_weekday,
+)
 from datahub.metadata.com.linkedin.pegasus2avro.common import Status
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import DatasetSnapshot
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
@@ -202,6 +205,10 @@ class IcebergSource(StatefulIngestionSourceBase):
         if self.config.is_profiling_enabled():
             profiler = IcebergProfiler(self.report, self.config.profiling)
             yield from profiler.profile_table(dataset_name, dataset_urn, table)
+        elif self.config.is_weekly_stripping_enabled():
+            if is_hash_mod_matching_weekday(dataset_urn):
+                profiler = IcebergProfiler(self.report, self.config.profiling)
+                yield from profiler.profile_table(dataset_name, dataset_urn, table)
 
     def _get_ownership_aspect(self, table: Table) -> Optional[OwnershipClass]:
         owners = []

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
@@ -24,7 +24,8 @@ from datahub.ingestion.source.state.stateful_ingestion_base import (
 )
 from datahub.ingestion.source_config.operation_config import (
     OperationConfig,
-    is_profiling_enabled,
+    is_unified_profiling_enabled,
+    is_weekly_stripping_enabled,
 )
 
 
@@ -91,7 +92,12 @@ class IcebergSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin)
     profiling: IcebergProfilingConfig = IcebergProfilingConfig()
 
     def is_profiling_enabled(self) -> bool:
-        return self.profiling.enabled and is_profiling_enabled(
+        return self.profiling.enabled and is_unified_profiling_enabled(
+            self.profiling.operation_config
+        )
+
+    def is_weekly_stripping_enabled(self) -> bool:
+        return self.profiling.enabled and is_weekly_stripping_enabled(
             self.profiling.operation_config
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
@@ -18,6 +18,9 @@ from datahub.ingestion.source.sql.sql_generic_profiler import (
     TableProfilerRequest,
 )
 from datahub.ingestion.source.state.profiling_state_handler import ProfilingHandler
+from datahub.ingestion.source_config.operation_config import (
+    is_hash_mod_matching_weekday,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +100,13 @@ class RedshiftProfiler(GenericProfiler):
                     self.state_handler.add_to_state(
                         dataset_urn, int(datetime.now().timestamp() * 1000)
                     )
+
+        if self.config.is_profiling_enabled():
+            yield MetadataChangeProposalWrapper(
+                entityUrn=dataset_urn, aspect=profile
+            ).as_workunit()
+        elif self.config.is_weekly_stripping_enabled():
+            if is_hash_mod_matching_weekday(dataset_urn):
 
                 yield MetadataChangeProposalWrapper(
                     entityUrn=dataset_urn, aspect=profile

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -408,7 +408,10 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
                 connection=connection, all_tables=all_tables, database=database
             )
 
-        if self.config.is_profiling_enabled():
+        if (
+            self.config.is_profiling_enabled()
+            or self.config.is_weekly_stripping_enabled()
+        ):
             profiler = RedshiftProfiler(
                 config=self.config,
                 report=self.report,

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
@@ -18,7 +18,10 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
-from datahub.ingestion.source_config.operation_config import is_profiling_enabled
+from datahub.ingestion.source_config.operation_config import (
+    is_unified_profiling_enabled,
+    is_weekly_stripping_enabled,
+)
 
 # hide annoying debug errors from py4j
 logging.getLogger("py4j").setLevel(logging.ERROR)
@@ -91,7 +94,12 @@ class DataLakeSourceConfig(
     )
 
     def is_profiling_enabled(self) -> bool:
-        return self.profiling.enabled and is_profiling_enabled(
+        return self.profiling.enabled and is_unified_profiling_enabled(
+            self.profiling.operation_config
+        )
+
+    def is_weekly_stripping_enabled(self) -> bool:
+        return self.profiling.enabled and is_weekly_stripping_enabled(
             self.profiling.operation_config
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -272,7 +272,7 @@ class SnowflakeV2Source(
                 run_id=self.ctx.run_id,
             )
 
-        if config.is_profiling_enabled():
+        if config.is_profiling_enabled() or self.config.is_weekly_stripping_enabled():
             # For profiling
             self.profiler = SnowflakeProfiler(
                 config, self.report, self.profiling_state_handler
@@ -701,7 +701,10 @@ class SnowflakeV2Source(
         for snowflake_schema in snowflake_db.schemas:
             yield from self._process_schema(snowflake_schema, db_name)
 
-        if self.config.is_profiling_enabled() and self.db_tables:
+        if (
+            self.config.is_profiling_enabled()
+            or self.config.is_weekly_stripping_enabled()
+        ) and self.db_tables:
             yield from self.profiler.get_workunits(snowflake_db, self.db_tables)
 
     def fetch_schemas_for_database(self, snowflake_db, db_name):

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
@@ -16,7 +16,10 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
-from datahub.ingestion.source_config.operation_config import is_profiling_enabled
+from datahub.ingestion.source_config.operation_config import (
+    is_unified_profiling_enabled,
+    is_weekly_stripping_enabled,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -68,7 +71,12 @@ class SQLCommonConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin):
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = None
 
     def is_profiling_enabled(self) -> bool:
-        return self.profiling.enabled and is_profiling_enabled(
+        return self.profiling.enabled and is_unified_profiling_enabled(
+            self.profiling.operation_config
+        )
+
+    def is_weekly_stripping_enabled(self) -> bool:
+        return self.profiling.enabled and is_weekly_stripping_enabled(
             self.profiling.operation_config
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -19,7 +19,8 @@ from datahub.ingestion.source.state.stateful_ingestion_base import (
 from datahub.ingestion.source.usage.usage_common import BaseUsageConfig
 from datahub.ingestion.source_config.operation_config import (
     OperationConfig,
-    is_profiling_enabled,
+    is_unified_profiling_enabled,
+    is_weekly_stripping_enabled,
 )
 
 
@@ -151,7 +152,12 @@ class UnityCatalogSourceConfig(
     )
 
     def is_profiling_enabled(self) -> bool:
-        return self.profiling.enabled and is_profiling_enabled(
+        return self.profiling.enabled and is_unified_profiling_enabled(
+            self.profiling.operation_config
+        )
+
+    def is_weekly_stripping_enabled(self) -> bool:
+        return self.profiling.enabled and is_weekly_stripping_enabled(
             self.profiling.operation_config
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/connection_test.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/connection_test.py
@@ -60,7 +60,10 @@ class UnityCatalogConnectionTest:
             return CapabilityReport(capable=False, failure_reason=str(e))
 
     def profiling_connectivity(self) -> Optional[CapabilityReport]:
-        if not self.config.is_profiling_enabled():
+        if (
+            not self.config.is_profiling_enabled()
+            and not self.config.is_weekly_stripping_enabled()
+        ):
             return None
         try:
             return CapabilityReport(capable=self.proxy.check_profiling_connectivity())

--- a/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import logging
 from typing import Any, Dict, Optional
 
@@ -15,6 +16,13 @@ class OperationConfig(ConfigModel):
         default=False,
         description="Whether to do profiling at lower freq or not. This does not do any scheduling just adds additional checks to when not to run profiling.",
     )
+
+    weekly_striping_enabled: bool = Field(
+        default=False,
+        description="Whether to distribute the profiling over a week, with each day focusing on a 1/7 portion of the data.If profiling at lower freq and weekly_striping_enabled are enabled,\
+          profile day of week and profile date of month fields does not take affect.",
+    )
+
     profile_day_of_week: Optional[int] = Field(
         default=None,
         description="Number between 0 to 6 for day of week (both inclusive). 0 is Monday and 6 is Sunday. If not specified, defaults to Nothing and this field does not take affect.",
@@ -28,14 +36,28 @@ class OperationConfig(ConfigModel):
     def lower_freq_configs_are_set(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         lower_freq_profile_enabled = values.get("lower_freq_profile_enabled")
         profile_day_of_week = values.get("profile_day_of_week")
+        weekly_striping_enabled = values.get("weekly_striping_enabled")
         profile_date_of_month = values.get("profile_date_of_month")
         if (
             lower_freq_profile_enabled
+            and (weekly_striping_enabled is None or weekly_striping_enabled is False)
             and profile_day_of_week is None
             and profile_date_of_month is None
         ):
             raise ConfigurationError(
                 "Lower freq profiling setting is enabled but no day of week or date of month is specified. Profiling will be done.",
+            )
+        return values
+
+    @pydantic.root_validator(pre=True)
+    def weekly_stripping_enabled(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        lower_freq_profile_enabled = values.get("lower_freq_profile_enabled")
+        weekly_striping_enabled = values.get("weekly_striping_enabled")
+        if weekly_striping_enabled and (
+            lower_freq_profile_enabled is None or lower_freq_profile_enabled is False
+        ):
+            raise ConfigurationError(
+                "Weekly profiling is enabled but lower freq profiling is disabled.",
             )
         return values
 
@@ -62,10 +84,13 @@ class OperationConfig(ConfigModel):
         return profile_date_of_month
 
 
-def is_profiling_enabled(operation_config: OperationConfig) -> bool:
+def is_unified_profiling_enabled(operation_config: OperationConfig) -> bool:
     if operation_config.lower_freq_profile_enabled is False:
         return True
     logger.info("Lower freq profiling setting is enabled.")
+    if operation_config.weekly_striping_enabled is True:
+        logger.info("Weekly stripping setting is enabled.")
+        return False
     today = datetime.date.today()
     if (
         operation_config.profile_day_of_week is not None
@@ -84,3 +109,28 @@ def is_profiling_enabled(operation_config: OperationConfig) -> bool:
         )
         return False
     return True
+
+
+def is_weekly_stripping_enabled(operation_config: OperationConfig) -> bool:
+    if (
+        operation_config.weekly_striping_enabled
+        and operation_config.lower_freq_profile_enabled is True
+    ):
+        return True
+    return False
+
+
+def is_hash_mod_matching_weekday(datasetUrn: str) -> bool:
+
+    """
+    Checks if the consistent hash and mod 7 value equals weekday.
+    Args:
+        datasetUrn or table name
+    Returns:
+        bool: True if the hash value corresponds to the target weekday, False otherwise.
+    """
+
+    md5_hash = int(hashlib.md5(str(datasetUrn).encode()).hexdigest(), 16) % 7
+    if md5_hash == datetime.date.today().weekday():
+        return True
+    return False


### PR DESCRIPTION
`weekly_striping` : This operator is meant to process one-seventh (1/7) of the all table's data each day. Distribute the profiling task over a week, with each day focusing on a different portion of the data.

using `hashlib.md5` for consistent hashing of a given dataset-name/dataset-urn/table-name.
Checks if the consistent hash and mod 7 value equals weekday.

`weekly_striping` will be considered enabled when `lower_freq_profile_enabled` & `weekly_striping` are `True` are enabled.
If `lower_freq_profile_enabled` is `True` and `weekly_striping` is `False` , then `profile_day_of_week` & `profile_date_of_month` will be checked for unified/bulk profiling ( backward compatible).

	operation_config:
  		lower_freq_profile_enabled: True 
  		weekly_striping : True
  		profile_day_of_week: null
  		profile_date_of_month: null


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
